### PR TITLE
fix validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "temptifly",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "temptifly",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "Side-by-side YAML resource editor",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/validate-controls.js
+++ b/src/utils/validate-controls.js
@@ -32,7 +32,7 @@ export function validateControls(
     },
   }
   otherYAMLTabs.forEach(({ id, templateYAML: yaml }, inx) => {
-    ({ parsed, exceptions } = parseYAML(yaml))
+    ;({ parsed, exceptions } = parseYAML(yaml))
     templateObjectMap[id] = parsed
     templateExceptionMap[id] = {
       editor: editors[inx + 1],
@@ -69,39 +69,39 @@ export function validateControls(
       delete control.exception
       if (!stopValidating) {
         switch (type) {
-        case 'group':
-          validateGroupControl(
-            active,
-            controlData,
-            templateObjectMap,
-            templateExceptionMap,
-            isFinalValidate,
-            i18n
-          )
-          break
+          case 'group':
+            validateGroupControl(
+              active,
+              controlData,
+              templateObjectMap,
+              templateExceptionMap,
+              isFinalValidate,
+              i18n
+            )
+            break
 
-        case 'table':
-          control.exceptions = []
-          validateTableControl(
-            control,
-            controlData,
-            templateObjectMap,
-            templateExceptionMap,
-            isFinalValidate,
-            i18n
-          )
-          break
+          case 'table':
+            control.exceptions = []
+            validateTableControl(
+              control,
+              controlData,
+              templateObjectMap,
+              templateExceptionMap,
+              isFinalValidate,
+              i18n
+            )
+            break
 
-        default:
-          validateControl(
-            control,
-            controlData,
-            templateObjectMap,
-            templateExceptionMap,
-            isFinalValidate,
-            i18n
-          )
-          break
+          default:
+            validateControl(
+              control,
+              controlData,
+              templateObjectMap,
+              templateExceptionMap,
+              isFinalValidate,
+              i18n
+            )
+            break
         }
       }
       if (pauseControlCreationHereUntilSelected) {
@@ -303,61 +303,61 @@ const validateControl = (
 
   if (shouldValidateControl(control)) {
     switch (control.type) {
-    case 'text':
-    case 'textarea':
-    case 'number':
-    case 'combobox':
-    case 'toggle':
-    case 'hidden':
-      validateTextControl(
-        control,
-        templateObjectMap,
-        templateExceptionMap,
-        isFinalValidate,
-        i18n
-      )
-      break
-    case 'checkbox':
-      validateCheckboxControl(
-        control,
-        templateObjectMap,
-        templateExceptionMap,
-        i18n
-      )
-      break
-    case 'cards':
-      validateCardsControl(
-        control,
-        templateObjectMap,
-        templateExceptionMap,
-        i18n
-      )
-      break
-    case 'singleselect':
-      validateSingleSelectControl(
-        control,
-        templateObjectMap,
-        templateExceptionMap,
-        i18n
-      )
-      break
-    case 'multiselect':
-      validateMultiSelectControl(
-        control,
-        templateObjectMap,
-        templateExceptionMap,
-        i18n
-      )
-      break
-    case 'table':
-      validateTableControl(
-        control,
-        controlData,
-        templateObjectMap,
-        templateExceptionMap,
-        i18n
-      )
-      break
+      case 'text':
+      case 'textarea':
+      case 'number':
+      case 'combobox':
+      case 'toggle':
+      case 'hidden':
+        validateTextControl(
+          control,
+          templateObjectMap,
+          templateExceptionMap,
+          isFinalValidate,
+          i18n
+        )
+        break
+      case 'checkbox':
+        validateCheckboxControl(
+          control,
+          templateObjectMap,
+          templateExceptionMap,
+          i18n
+        )
+        break
+      case 'cards':
+        validateCardsControl(
+          control,
+          templateObjectMap,
+          templateExceptionMap,
+          i18n
+        )
+        break
+      case 'singleselect':
+        validateSingleSelectControl(
+          control,
+          templateObjectMap,
+          templateExceptionMap,
+          i18n
+        )
+        break
+      case 'multiselect':
+        validateMultiSelectControl(
+          control,
+          templateObjectMap,
+          templateExceptionMap,
+          i18n
+        )
+        break
+      case 'table':
+        validateTableControl(
+          control,
+          controlData,
+          templateObjectMap,
+          templateExceptionMap,
+          i18n
+        )
+        break
     }
   }
 }
@@ -372,9 +372,9 @@ const attachEditorToExceptions = (exceptions, editors, inx) => {
 
 const shouldValidateControl = (control) => {
   let required = false
-  const { sourcePath, validation, active } = control
-  if (sourcePath && validation) {
-    ({ required } = validation)
+  const { validation, active } = control
+  if (validation) {
+    ;({ required } = validation)
     if (!required) {
       // if not required, only validate if that yaml path exists
       return !!active


### PR DESCRIPTION
stolostron/backlog#17851

this wasn't a regression per se --- it was a missing use case:
1. if user edited the vip in the form when the Install Configuration tab happened to be open it would work
2. if user edited the vip value directly in the yaml it would work
3. but if the user edited vip in the form with the Main tab was open it wouldn't work

why it wasn't working because:
1. if the user changes form or yaml, all validation goes through validateControls
2. after validateControls verifies the yaml has no syntax errors, it uses reverse() to get values from yaml and stuff into control.active
3. to do this it uses sourcePathMap which is either created from the ## tag in the yaml file or from the reversePath path on the control (## are mostly used in create cluster wizard// reversePath is mostly used in application subscription)
4. it does this in setActiveValue which determines what the sourcePath to use and then does a get
5. this sourcePath is then stuffed into the control
6. validateControls shouldn't validate any control that has no validation and has no active value --otherwise the first time you type anything into any input, the whole form would light up with validation errors--it does this check in shouldValidateControl which checks to make sure sourcePath is set
7. BUT in if the active tab is not the tab the sourcePathMap that setActiveValue checks for, sourcePath is never set
8. SO when the shouldValidateControl never returns true--unless you open that tab and type in the form or in the yaml

Signed-off-by: John Swanke <jswanke@redhat.com>